### PR TITLE
feat : store_id기준 일별, 월별 정산내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssg/webpos/config/SecurityConfig.java
+++ b/src/main/java/com/ssg/webpos/config/SecurityConfig.java
@@ -18,7 +18,8 @@ public class SecurityConfig {
     private static final String[] PERMIT_URL = {
             "/api/v1/branchadmin-staff/join", "/api/v1/branchadmin-staff/login",
             "/api/v1/branchadmin-manager/join", "/api/v1/branchadmin-manage/login",
-            "/api/v1/hqadmin/join", "/api/v1/hqadmin/login"
+            "/api/v1/hqadmin/join", "/api/v1/hqadmin/login",
+            "/api/v1/manager/settlement-day/**"
     };
 
     @Bean

--- a/src/main/java/com/ssg/webpos/controller/admin/BranchSettlementController.java
+++ b/src/main/java/com/ssg/webpos/controller/admin/BranchSettlementController.java
@@ -1,0 +1,136 @@
+package com.ssg.webpos.controller.admin;
+
+import com.ssg.webpos.domain.BranchAdmin;
+import com.ssg.webpos.domain.SettlementDay;
+import com.ssg.webpos.domain.SettlementMonth;
+import com.ssg.webpos.dto.SettlementDayReportDTO;
+import com.ssg.webpos.repository.settlement.SettlementDayRepository;
+import com.ssg.webpos.repository.settlement.SettlementMonthRepository;
+import com.ssg.webpos.service.SettlementDayService;
+import com.ssg.webpos.service.SettlementMonthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/manager")
+@Slf4j
+@RequiredArgsConstructor
+public class BranchSettlementController {
+    private final SettlementDayRepository settlementDayRepository;
+    private final SettlementMonthRepository settlementMonthRepository;
+    private final SettlementDayService settlementDayService;
+    private final SettlementMonthService settlementMonthService;
+
+    // settlement_day 전체 내역 조회 GET
+    @GetMapping("/settlement-day")
+    public List<SettlementDayReportDTO> getSettlementDayReport() {
+        List<SettlementDay> settlementDays = settlementDayRepository.findAll();
+        List<SettlementDayReportDTO> reportDTOs = new ArrayList<>();
+
+        for (SettlementDay settlementDay : settlementDays) {
+            SettlementDayReportDTO reportDTO = new SettlementDayReportDTO();
+            reportDTO.setSettlementDayId(settlementDay.getId());
+            reportDTO.setSettlementPrice(settlementDay.getSettlementPrice());
+            reportDTO.setSettlementDate(settlementDay.getSettlementDate());
+            reportDTO.setStoreId(settlementDay.getStore().getId());
+            reportDTO.setCreatedDate(settlementDay.getCreatedDate());
+            reportDTOs.add(reportDTO);
+        }
+
+        return reportDTOs;
+    }
+    //조건을 명시한 상태에서 settlement_day 내역 GET (조건 : store_id=1L, settlement_date="2023-05-08")
+    @GetMapping("/test1")
+    public List<SettlementDayReportDTO> test1() { //점장 로그인 기능 구현시 팀장님 코드 활용
+//        팀장님 작성 BranchAdmin branchAdmin = principalDetail.getUser(); 이거 활용해서 로그인한 사람의 소속 가게 store_id불러올 수 있다.
+//        팀장님 작성 Long storeId = branchAdmin.getStore().getId();
+//        지금 해야하는 것 : 요청 받은 날짜의 결제 내역을 나오게 하는 것
+        List<SettlementDay> settlementDays = settlementDayService.selectByStoreIdAndDay(1L,"2023-05-08");
+        List<SettlementDayReportDTO> reportDTOs = new ArrayList<>();
+
+        for (SettlementDay settlementDay : settlementDays) {
+            SettlementDayReportDTO reportDTO = new SettlementDayReportDTO();
+            reportDTO.setSettlementDayId(settlementDay.getId());
+            reportDTO.setSettlementPrice(settlementDay.getSettlementPrice());
+            reportDTO.setSettlementDate(settlementDay.getSettlementDate());
+            reportDTO.setStoreId(settlementDay.getStore().getId());
+            reportDTO.setCreatedDate(settlementDay.getCreatedDate());
+            reportDTOs.add(reportDTO);
+        }
+
+        return reportDTOs;
+    }
+
+    @GetMapping("/test2")
+    public List<SettlementDayReportDTO> test2(@RequestParam("settlementDate")String SettlementDate) throws DateTimeParseException {
+        // 20022-05-08같이 테이블에 없는 날짜 내역이 올 경우 에러 -> DateTimeParseException
+        try {
+            List<SettlementDay> settlementDays = settlementDayService.selectByStoreIdAndDay(1L,SettlementDate);
+            List<SettlementDayReportDTO> reportDTOs = new ArrayList<>();
+
+            for (SettlementDay settlementDay : settlementDays) {
+                SettlementDayReportDTO reportDTO = new SettlementDayReportDTO();
+                reportDTO.setSettlementDayId(settlementDay.getId());
+                reportDTO.setSettlementPrice(settlementDay.getSettlementPrice());
+                reportDTO.setSettlementDate(settlementDay.getSettlementDate());
+                reportDTO.setStoreId(settlementDay.getStore().getId());
+                reportDTO.setCreatedDate(settlementDay.getCreatedDate());
+                reportDTOs.add(reportDTO);
+            }
+
+            return reportDTOs;
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+
+    }
+
+//     코드 시작
+//    @PostMapping("/settlement-day")
+//    public ResponseEntity<SettlementDayResponseDTO> getSettlementDayByDate (
+//            // @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+//            @RequestBody SettlementDayRequestDTO requestDTO) {
+//        String dateStr = requestDTO.getDate();
+//        System.out.println("dateStr = " + dateStr);
+//        LocalDate date = LocalDate.parse(dateStr, DateTimeFormatter.ISO_DATE);
+//        System.out.println(date);
+//        try {
+//            List<SettlementDay> settlementDayListByDay = settlementDayRepository.findBySettlementDate(date);
+//            for (SettlementDay settlementDay : settlementDayListByDay) {
+//                System.out.println("settlementDay = " + settlementDay);
+//            }
+//            SettlementDayResponseDTO responseDTO = new SettlementDayResponseDTO(settlementDayListByDay);
+//            return new ResponseEntity(responseDTO ,HttpStatus.OK);
+//        } catch (Exception e) {
+//            log.error("Error occurred", e);
+//            return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+//        }
+//    }
+//     팀장님 코드 종료
+
+
+
+
+//    public ResponseEntity<List<SettlementDay>> GetSettlementDayByDate() throws Exception {
+//        LocalDate localDate = LocalDate.parse("2023-05-08");
+//        List<SettlementDay> settlementDayListByDay = settlementDayRepository.findBySettlementDate(localDate);
+//        return new ResponseEntity(settlementDayListByDay, HttpStatus.OK);
+//    }
+
+    // 점장의 정산 내역 조회 페이지 (월별 조회 페이지, 디폴트 : 2023.04 정산내역 표시)
+    // 점장이 HQ에게 일별 정산 내역 제출
+    // 점장이 HQ에게 월별 정산 내역 제출
+
+
+}

--- a/src/main/java/com/ssg/webpos/controller/admin/HQSettlementController.java
+++ b/src/main/java/com/ssg/webpos/controller/admin/HQSettlementController.java
@@ -1,0 +1,17 @@
+package com.ssg.webpos.controller.admin;
+
+import com.ssg.webpos.repository.settlement.SettlementDayRepository;
+import com.ssg.webpos.repository.settlement.SettlementMonthRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/hq")
+@Slf4j
+@RequiredArgsConstructor
+public class HQSettlementController {
+    private final SettlementDayRepository settlementDayRepository;
+    private final SettlementMonthRepository settlementMonthRepository;
+}

--- a/src/main/java/com/ssg/webpos/controller/admin/SettlementDayResponseDTO.java
+++ b/src/main/java/com/ssg/webpos/controller/admin/SettlementDayResponseDTO.java
@@ -1,0 +1,16 @@
+// 팀장님 작성 코드
+
+//package com.ssg.webpos.controller.admin;
+//
+//import com.ssg.webpos.domain.SettlementDay;
+//import lombok.AllArgsConstructor;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//import java.util.List;
+//@Data
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class SettlementDayResponseDTO {
+//    private List<SettlementDay> SettlementDayList;
+//}

--- a/src/main/java/com/ssg/webpos/domain/SettlementDay.java
+++ b/src/main/java/com/ssg/webpos/domain/SettlementDay.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "settlement_day")
+@ToString(of = {"id", "settlementPrice", "settlementDate", "createdDate"}) //출력할 필드 지정. store는 출렭되지 않음
 @EntityListeners(AuditingEntityListener.class)
 public class SettlementDay extends BaseTime {
     @Id

--- a/src/main/java/com/ssg/webpos/domain/SettlementMonth.java
+++ b/src/main/java/com/ssg/webpos/domain/SettlementMonth.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @Table(name = "settlement_month")
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString(of = {"id", "settlementPrice", "settlementDate"})
 @EntityListeners(AuditingEntityListener.class)
 public class SettlementMonth {
     @Id

--- a/src/main/java/com/ssg/webpos/dto/SettlementDayReportDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/SettlementDayReportDTO.java
@@ -1,0 +1,20 @@
+package com.ssg.webpos.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SettlementDayReportDTO {
+    private Long settlementDayId;
+    private int settlementPrice;
+    private LocalDate settlementDate;
+
+    private Long storeId;
+    private LocalDateTime createdDate;
+}

--- a/src/main/java/com/ssg/webpos/repository/report/SettlementDayReportRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/report/SettlementDayReportRepository.java
@@ -1,0 +1,4 @@
+package com.ssg.webpos.repository.report;
+
+public class SettlementDayReportRepository {
+}

--- a/src/main/java/com/ssg/webpos/repository/settlement/SettlementDayRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/settlement/SettlementDayRepository.java
@@ -1,0 +1,21 @@
+package com.ssg.webpos.repository.settlement;
+
+import com.ssg.webpos.domain.SettlementDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface SettlementDayRepository extends JpaRepository<SettlementDay, Long> {
+    //store_id별 조회(HQ 활용)
+    // @Query("SELECT s FROM SettlementDay s where s.storeId = :storeId")
+    List<SettlementDay> findByStoreId(Long storeId);
+    //일별 조회(HQ 활용)
+    List<SettlementDay> findBySettlementDate(LocalDate settlementDate);
+    // store_id, 일별 조회(점장 활용)
+    List<SettlementDay> findByStoreIdAndSettlementDate(Long storeId, LocalDate settlementDate);
+}

--- a/src/main/java/com/ssg/webpos/repository/settlement/SettlementMonthRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/settlement/SettlementMonthRepository.java
@@ -1,0 +1,18 @@
+package com.ssg.webpos.repository.settlement;
+
+
+import com.ssg.webpos.domain.SettlementMonth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SettlementMonthRepository extends JpaRepository<SettlementMonth, Long> {
+    //store_id별 조회(HQ 활용)
+    // @Query("SELECT s FROM SettlementDay s where s.storeId = :storeId")
+    List<SettlementMonth> findByStoreId(Long storeId);
+    //일별 조회(HQ 활용)
+    List<SettlementMonth> findBySettlementDate(LocalDate settlementDate);
+    // store_id, 일별 조회(접장 활용)
+    List<SettlementMonth> findByStoreIdAndSettlementDate(Long storeId, LocalDate settlementDate);
+}

--- a/src/main/java/com/ssg/webpos/service/SettlementDayService.java
+++ b/src/main/java/com/ssg/webpos/service/SettlementDayService.java
@@ -1,0 +1,58 @@
+package com.ssg.webpos.service;
+
+import com.ssg.webpos.domain.SettlementDay;
+import com.ssg.webpos.repository.settlement.SettlementDayRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional // readOnly = true
+public class SettlementDayService {
+    private final SettlementDayRepository settlementDayRepository;
+
+    //store_id별 조회(HQ 활용)
+    public List<SettlementDay> selectByStoreId(Long storeId) {
+        try {
+            List<SettlementDay> list = settlementDayRepository.findByStoreId(storeId);
+            return list;
+        }catch (Exception e) {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+
+    //일별 조회(HQ 활용)
+    public List<SettlementDay> selectByDay(String settlementDate) throws DateTimeParseException {
+        try{
+            LocalDate localDate = LocalDate.parse(settlementDate);
+            List<SettlementDay> list = settlementDayRepository.findBySettlementDate(localDate);
+            return list;
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println(e);
+            return Collections.emptyList();
+        }
+    }
+
+    //store_id별,일별 조회(점장 활용)
+    public List<SettlementDay> selectByStoreIdAndDay(Long storeId, String settlementDate) throws DateTimeParseException {
+        try{
+            LocalDate localDate = LocalDate.parse(settlementDate);
+            List<SettlementDay> list = settlementDayRepository.findByStoreIdAndSettlementDate(storeId,localDate);
+            return list;
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println(e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/ssg/webpos/service/SettlementMonthService.java
+++ b/src/main/java/com/ssg/webpos/service/SettlementMonthService.java
@@ -1,0 +1,55 @@
+package com.ssg.webpos.service;
+
+import com.ssg.webpos.domain.SettlementMonth;
+import com.ssg.webpos.repository.settlement.SettlementMonthRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SettlementMonthService {
+    private final SettlementMonthRepository settlementMonthRepository;
+
+    //store_id별 조회(HQ 활용)
+    public List<SettlementMonth> selectByStoreId(Long storeId) throws IllegalStateException {
+        try {
+            List<SettlementMonth> list = settlementMonthRepository.findByStoreId(storeId);
+            return list;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+    //일별 조회(HQ 활용)
+    public List<SettlementMonth> selectByDay(String settlementDate) throws DateTimeParseException {
+       try{
+            LocalDate localDate = LocalDate.parse(settlementDate);
+            List<SettlementMonth> list = settlementMonthRepository.findBySettlementDate(localDate);
+            return list;
+       } catch (Exception e) {
+           e.printStackTrace();
+           System.out.println(e);
+           return Collections.emptyList();
+       }
+    }
+    //store_id별,일별 조회(점장 활용)
+    public List<SettlementMonth> selectByStoreIdAndDay(Long storeId, String settlementDate) throws DateTimeParseException {
+        try {
+            LocalDate localDate = LocalDate.parse(settlementDate);
+            List<SettlementMonth> list = settlementMonthRepository.findByStoreIdAndSettlementDate(storeId,localDate);
+            return list;
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println(e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/test/java/com/ssg/webpos/service/SettlementSelectServiceTest.java
+++ b/src/test/java/com/ssg/webpos/service/SettlementSelectServiceTest.java
@@ -1,0 +1,85 @@
+package com.ssg.webpos.service;
+
+import com.ssg.webpos.domain.SettlementDay;
+import com.ssg.webpos.domain.SettlementMonth;
+import com.ssg.webpos.repository.settlement.SettlementDayRepository;
+import com.ssg.webpos.repository.settlement.SettlementMonthRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest
+public class SettlementSelectServiceTest {
+
+    @Autowired
+    SettlementDayRepository settlementDayRepository;
+    @Autowired
+    SettlementMonthRepository settlementMonthRepository;
+    @Autowired
+    SettlementDayService settlementDayService;
+    @Autowired
+    SettlementMonthService settlementMonthService;
+
+    @Test
+    void selectSettlementDayByStoreIdTest() throws IllegalArgumentException {
+        Long storeId = 1L;
+        List<SettlementDay> settlementDayList = settlementDayService.selectByStoreId(storeId);
+        System.out.println(settlementDayList);
+        Assertions.assertEquals(1, settlementDayList.size());
+    }
+
+    @Test
+    void selectSettlementDayByDayTest() {
+        String localdate = "51515";
+        List<SettlementDay> list = settlementDayService.selectByDay(localdate);
+        System.out.println(list);
+    }
+
+    @Test
+    void selectSettlementDayByStoreIdAndDayTest() {
+        Long storeId = 1L;
+        String localdate = "2023-05-08";
+        List<SettlementDay> list = settlementDayService.selectByStoreIdAndDay(storeId,localdate);
+        System.out.println(list);
+        Assertions.assertEquals(1,list.size());
+    }
+
+    @Test
+    void selectSettlementMonthByStoreIdTest() {
+        Long storeId = 1L;
+        List<SettlementMonth> settlementMonthListByStoreId = settlementMonthRepository.findByStoreId(storeId);
+        System.out.println(settlementMonthListByStoreId);
+        // store_id가 안불러진다.
+    }
+
+    @Test
+    void selectSettlementMonthByDayTest() {
+        LocalDate localdate = LocalDate.parse("2023-04-01");
+        List<SettlementMonth> settlementMonthListByDay = settlementMonthRepository.findBySettlementDate(localdate);
+        System.out.println(settlementMonthListByDay);
+    }
+
+    @Test
+    void selectSettlementMonthByStoreIdAndDayTest() {
+        Long storeId = 1L;
+        LocalDate localdate = LocalDate.parse("2023-05-08");
+        List<SettlementMonth> settlementMonthListByStoreIdAndDay = settlementMonthRepository.findByStoreIdAndSettlementDate(storeId,localdate);
+        System.out.println(settlementMonthListByStoreIdAndDay);
+    }
+    @Test
+    @DisplayName("날짜 형식이 잘못된 경우")
+    void selectSettlementDayByDayTest2() {
+        String localdate = "2023-05-08";
+        List<SettlementDay> settlementDayList = settlementDayService.selectByDay(localdate);
+        System.out.println(settlementDayList);
+//        Assertions.assertThrows(IllegalArgumentException.class,throw new RuntimeException);
+    }
+}


### PR DESCRIPTION
+ BranchSettlementController 생성 : Manager의 일별 정산내역 조회
+ HQSettlementController 생성 : HQ의 일별 정산내역 조회
+ SettlementDayResponseDTO : REST API를 위한 settlement_day 데이터 전송 DTO
+ SettlementDay, SettlementMonth : @ToString(of = {"id", "settlementPrice", "settlementDate", "createdDate"}) 변경
+ SettlementDayRepository, SettlementMonthRepository, SettlementDayService, SettlementMonthService : 조회를 위한 매서드 생성
+ 정산내역 조회 테스트 코드 작성