### PR TITLE
feat: 주문 취소 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/ssg/webpos/domain/PointSaveHistory.java
+++ b/src/main/java/com/ssg/webpos/domain/PointSaveHistory.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-//@ToString
+@ToString
 @Table(name = "point_save_history")
 public class PointSaveHistory extends BaseTime {
   @Id
@@ -35,14 +35,4 @@ public class PointSaveHistory extends BaseTime {
   private Order order;
 
   private byte pointStatus; // 0: 적립, 1: 취소
-
-//  @Override
-//  public String toString() {
-//    return "PointSaveHistory{" +
-//        "id=" + id +
-//        ", amount=" + amount +
-//        ", user=" + user +
-//        ", order=" + order +
-//        '}';
-//  }
 }

--- a/src/main/java/com/ssg/webpos/domain/PointUseHistory.java
+++ b/src/main/java/com/ssg/webpos/domain/PointUseHistory.java
@@ -34,4 +34,15 @@ public class PointUseHistory extends BaseTime {
         this.user = user;
         this.order = order;
     }
+
+    @Override
+    public String toString() {
+        return "PointUseHistory{" +
+            "id=" + id +
+            ", amount=" + amount +
+            ", user=" + user +
+            ", order=" + order +
+            ", pointStatus=" + pointStatus +
+            '}';
+    }
 }

--- a/src/main/java/com/ssg/webpos/domain/User.java
+++ b/src/main/java/com/ssg/webpos/domain/User.java
@@ -1,5 +1,6 @@
 package com.ssg.webpos.domain;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.ssg.webpos.domain.enums.RoleUser;
 import lombok.*;
 
@@ -49,22 +50,17 @@ public class User extends BaseTime {
     @OneToMany(mappedBy = "user")
     private List<Coupon> couponList = new ArrayList<>();
 
-//    @Override
-//    public String toString() {
-//        return "User{" +
-//            "id=" + id +
-//            ", email='" + email + '\'' +
-//            ", password='" + password + '\'' +
-//            ", name='" + name + '\'' +
-//            ", birth=" + birth +
-//            ", phoneNumber='" + phoneNumber + '\'' +
-//            ", role=" + role +
-//            ", point=" + point +
-//            ", pointUseHistoryList=" + pointUseHistoryList +
-//            ", pointSaveHistoryList=" + pointSaveHistoryList +
-//            ", deliveryAddressList=" + deliveryAddressList +
-//            ", orderList=" + orderList +
-//            ", couponList=" + couponList +
-//            '}';
-//    }
+    @Override
+    public String toString() {
+        return "User{" +
+            "id=" + id +
+            ", email='" + email + '\'' +
+            ", password='" + password + '\'' +
+            ", name='" + name + '\'' +
+            ", birth=" + birth +
+            ", phoneNumber='" + phoneNumber + '\'' +
+            ", role=" + role +
+            ", point=" + point +
+            '}';
+    }
 }

--- a/src/main/java/com/ssg/webpos/repository/CouponRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/CouponRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
   Optional<Coupon> findBySerialNumber(String serialNumber);
+  Coupon findByOrderId(Long orderId);
 }

--- a/src/main/java/com/ssg/webpos/repository/PointSaveHistoryRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/PointSaveHistoryRepository.java
@@ -3,6 +3,8 @@ package com.ssg.webpos.repository;
 import com.ssg.webpos.domain.PointSaveHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PointSaveHistoryRepository extends JpaRepository<PointSaveHistory, Long> {
+import java.util.Optional;
 
+public interface PointSaveHistoryRepository extends JpaRepository<PointSaveHistory, Long> {
+  Optional<PointSaveHistory> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/ssg/webpos/service/CartService.java
+++ b/src/main/java/com/ssg/webpos/service/CartService.java
@@ -1,10 +1,15 @@
 package com.ssg.webpos.service;
 
 import com.ssg.webpos.domain.*;
+import com.ssg.webpos.domain.enums.CouponStatus;
 import com.ssg.webpos.domain.enums.OrderStatus;
 import com.ssg.webpos.domain.enums.PayMethod;
 import com.ssg.webpos.dto.cartDto.CartAddDTO;
 import com.ssg.webpos.dto.OrderDTO;
+import com.ssg.webpos.repository.CouponRepository;
+import com.ssg.webpos.repository.PointSaveHistoryRepository;
+import com.ssg.webpos.repository.PointUseHistoryRepository;
+import com.ssg.webpos.repository.UserRepository;
 import com.ssg.webpos.repository.cart.CartRepository;
 import com.ssg.webpos.repository.order.OrderRepository;
 import com.ssg.webpos.repository.pos.PosRepository;
@@ -23,7 +28,10 @@ public class CartService {
   private final CartRepository cartRepository;
   private final ProductRepository productRepository;
   private final PosRepository posRepository;
-
+  private final UserRepository userRepository;
+  private final PointUseHistoryRepository pointUseHistoryRepository;
+  private final PointSaveHistoryRepository pointSaveHistoryRepository;
+  private final CouponRepository couponRepository;
 
   // 장바구니 상품 개별 삭제
   @Transactional
@@ -108,16 +116,71 @@ public class CartService {
   }
 
   @Transactional
-  public void cancelOrder(Long orderId) {
-    Order order = orderRepository.findById(orderId).get();
+  public void cancelOrder(Long orderId, Long userId) {
+    Order order = orderRepository.findById(orderId).orElseThrow(
+        () -> new RuntimeException("주문 내역을 찾을 수 없습니다."));
     order.setOrderStatus(OrderStatus.CANCEL);
+    User findUser = userRepository.findById(userId).get();
+
+    // 사용한 포인트 반환
+    int currentPoint = findUser.getPoint();
+    System.out.println("currentPoint = " + currentPoint);
+
+    PointUseHistory findUsePoint = pointUseHistoryRepository.findByOrderId(orderId).orElseThrow(
+        () -> new RuntimeException("주문 시 사용한 포인트 내역이 없습니다."));
+    int usePointAmount = findUsePoint.getAmount();
+    System.out.println("usePointAmount = " + usePointAmount);
+
+    currentPoint += usePointAmount;
+    System.out.println("currentPoint = " + currentPoint);
+
+    findUser.setPoint(currentPoint);
+    userRepository.save(findUser);
+    findUsePoint.setPointStatus((byte) 1);
+    pointUseHistoryRepository.save(findUsePoint);
+
+    System.out.println("findUsePoint = " + findUsePoint);
+    System.out.println("findUser = " + findUser);
+
+    // 적립 포인트 취소
+    PointSaveHistory findSavePoint = pointSaveHistoryRepository.findByOrderId(orderId).orElseThrow(
+        () -> new RuntimeException("주문 시 적립한 포인트 내역이 없습니다."));
+    int savePointAmount = findSavePoint.getAmount();
+    System.out.println("savePointAmount = " + savePointAmount);
+
+    currentPoint -= savePointAmount;
+    System.out.println("currentPoint = " + currentPoint);
+
+    findUser.setPoint(currentPoint);
+    userRepository.save(findUser);
+    findSavePoint.setPointStatus((byte) 1);
+    pointSaveHistoryRepository.save(findSavePoint);
+
+    System.out.println("findSavePoint = " + findSavePoint);
+    System.out.println("findUser = " + findUser);
+
+    // 쿠폰 상태 변경
+    Coupon useCoupon = couponRepository.findByOrderId(orderId);
+    System.out.println("useCoupon = " + useCoupon);
+
+    if (useCoupon != null) {
+      useCoupon.setCouponStatus(CouponStatus.NOT_USED);
+      couponRepository.save(useCoupon);
+    } else {
+      System.out.println("주문 시 사용한 쿠폰이 없습니다.");
+    }
 
     // 재고 수량 증가
     List<Cart> cartList = order.getCartList();
+    System.out.println("cartList = " + cartList);
     for (Cart cart : cartList) {
       Product product = cart.getProduct();
+      System.out.println("product = " + product);
       int qty = cart.getQty();
+      System.out.println("qty = " + qty);
       product.plusStockQuantity(qty);
+      int stock = product.getStock();
+      System.out.println("stock = " + stock);
     }
 
     orderRepository.save(order);

--- a/src/test/java/com/ssg/webpos/repository/DeliveryRedisRepositoryTest.java
+++ b/src/test/java/com/ssg/webpos/repository/DeliveryRedisRepositoryTest.java
@@ -47,7 +47,7 @@ public class DeliveryRedisRepositoryTest {
         .postCode("48060")
         .build();
     deliveryAddList.add(deliveryAddDTO);
-    deliveryAddRequestDTO.setDeliveryAddList(deliveryAddList);
+//    deliveryAddRequestDTO.setDeliveryAddList(deliveryAddList);
 
     deliveryRedisImplRepository.saveDelivery(deliveryAddRequestDTO);
     Map<String, Map<String, List<Object>>> findDelivery = deliveryRedisImplRepository.findAll();


### PR DESCRIPTION
- 주문 취소를 하기 위해 `주문 취소 상태, 사용 포인트 및 적립 포인트,  재고량` 을 업데이트 하는 cancelOrder 메서드 구현
    - 주문 취소 상태 변경 : Order의 orderStatus를 `OrderStatus.CANCEL`로 변경
    - 사용 포인트 반환 : 'user의 point 값을 조회'하여 pointUseHistoryRepository에서 사용 포인트를 가져와서, `currentPoint += usePointAmount` 로 유저의 사용 포인트를 반환, pointStatus를 0에서 1로 변경(0: 사용, 1: 취소)
    -  적립 포인트 취소 : pointSaveHistoryRepository에서 적립된 포인트를 가져와서 `currentPoint -= savePointAmount`로 유저의 적립 포인트 취소, pointStatus를 0에서 1로 변경(0: 적립, 1: 취소)
    - 유저가 쿠폰을 사용했으면 couponStatus를 `USED -> NOT_USED`로 변경
    - 재고량 증가 : 주문한 수량만큼 재고량을 증가
- 주문 취소 전/후로 포인트양 비교하여 cancelOrder 메서드 테스트하는 코드 작성