### PR TITLE
refactor: 배송 및 선물하기 redis 캐싱 기능 로직 개선

### DIFF
--- a/src/main/java/com/ssg/webpos/domain/Delivery.java
+++ b/src/main/java/com/ssg/webpos/domain/Delivery.java
@@ -48,6 +48,7 @@ public class Delivery extends BaseTime {
     private String userName;
     private String requestInfo;
     private String postCode;
+    private byte isConfirmed; // 배송정보 수집 이용 동의 체크 여부, 0: 체크 안함, 1: 체크함
 
     @OneToOne(mappedBy = "delivery")
     @JsonManagedReference

--- a/src/main/java/com/ssg/webpos/domain/DeliveryAddress.java
+++ b/src/main/java/com/ssg/webpos/domain/DeliveryAddress.java
@@ -27,7 +27,7 @@ public class DeliveryAddress extends BaseTime {
     private String name;
     private String requestInfo;
     private String postCode;
-    private boolean isDefault;
+    private byte isDefault; // 0: default 배송지 X, 1: default 배송지 O
     private String deliveryName;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ssg/webpos/dto/delivery/DeliveryAddressDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/delivery/DeliveryAddressDTO.java
@@ -2,7 +2,6 @@ package com.ssg.webpos.dto.delivery;
 
 
 import com.ssg.webpos.domain.DeliveryAddress;
-import com.ssg.webpos.domain.PosStoreCompositeId;
 import lombok.*;
 
 import java.io.Serializable;
@@ -19,7 +18,7 @@ public class DeliveryAddressDTO implements Serializable {
   private String name;
   private String requestInfo;
   private String postCode;
-  private boolean isDefault;
+  private byte isDefault;
   private String deliveryName;
 
   public DeliveryAddressDTO(DeliveryAddress deliveryAddress) {
@@ -29,7 +28,7 @@ public class DeliveryAddressDTO implements Serializable {
     this.name = deliveryAddress.getName();
     this.requestInfo = deliveryAddress.getRequestInfo();
     this.postCode = deliveryAddress.getPostCode();
-    this.isDefault = deliveryAddress.isDefault();
+    this.isDefault = deliveryAddress.getIsDefault();
     this.deliveryName = deliveryAddress.getDeliveryName();
   }
 }

--- a/src/main/java/com/ssg/webpos/dto/delivery/DeliveryListRedisSelectDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/delivery/DeliveryListRedisSelectDTO.java
@@ -1,7 +1,5 @@
 package com.ssg.webpos.dto.delivery;
 
-import com.ssg.webpos.domain.DeliveryAddress;
-import com.ssg.webpos.domain.PosStoreCompositeId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/ssg/webpos/dto/delivery/DeliveryListRedisSelectRequestDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/delivery/DeliveryListRedisSelectRequestDTO.java
@@ -1,12 +1,24 @@
 package com.ssg.webpos.dto.delivery;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class DeliveryListRedisSelectRequestDTO {
   private Long storeId;
   private Long posId;
-  private List<DeliveryListRedisSelectDTO> selectedDeliveryAddress;
+  private String deliveryName;
+  private String userName;
+  private String address;
+  private String postCode;
+  private byte isDefault;
+  private String requestDeliveryTime;
+  private String requestInfo;
 }

--- a/src/main/java/com/ssg/webpos/dto/delivery/DeliveryRedisAddDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/delivery/DeliveryRedisAddDTO.java
@@ -1,6 +1,5 @@
 package com.ssg.webpos.dto.delivery;
 
-import com.ssg.webpos.domain.PosStoreCompositeId;
 import lombok.*;
 
 import java.io.Serializable;

--- a/src/main/java/com/ssg/webpos/dto/delivery/DeliveryRedisAddRequestDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/delivery/DeliveryRedisAddRequestDTO.java
@@ -2,16 +2,20 @@ package com.ssg.webpos.dto.delivery;
 
 import lombok.*;
 
-import java.util.List;
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @ToString
-
 public class DeliveryRedisAddRequestDTO {
   private Long storeId;
   private Long posId;
-  private List<DeliveryRedisAddDTO> deliveryAddList;
+
+  private String deliveryName;
+  private String userName;
+  private String address;
+  private String phoneNumber;
+  private String requestDeliveryTime;
+  private String postCode;
+  private byte isConfirmed;
 }

--- a/src/main/java/com/ssg/webpos/dto/gift/GiftRequestDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/gift/GiftRequestDTO.java
@@ -14,5 +14,7 @@ import java.util.List;
 public class GiftRequestDTO {
   private Long posId;
   private Long storeId;
-  private List<GiftDTO> giftRecipientInfo;
+  private String receiver;
+  private String phoneNumber;
+  private String sender;
 }

--- a/src/main/java/com/ssg/webpos/repository/delivery/DeliveryRedisImplRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/delivery/DeliveryRedisImplRepository.java
@@ -1,7 +1,6 @@
 package com.ssg.webpos.repository.delivery;
 
 import com.ssg.webpos.dto.delivery.*;
-import com.ssg.webpos.dto.gift.GiftDTO;
 import com.ssg.webpos.dto.gift.GiftRequestDTO;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -38,20 +37,23 @@ public class DeliveryRedisImplRepository implements DeliveryRedisRepository {
 
     List<Object> deliveryAddList = new ArrayList<>();
 
-    for (DeliveryRedisAddDTO deliveryAddDTO : deliveryRedisAddRequestDTO.getDeliveryAddList()) {
-      Map<String, Object> addDelivery = new HashMap<>();
-      addDelivery.put("deliveryName", deliveryAddDTO.getDeliveryName());
-      addDelivery.put("userName", deliveryAddDTO.getUserName());
-      addDelivery.put("address", deliveryAddDTO.getAddress());
-      addDelivery.put("phoneNumber", deliveryAddDTO.getPhoneNumber());
-      addDelivery.put("requestDeliveryTime", deliveryAddDTO.getRequestDeliveryTime());
-      addDelivery.put("postCode", deliveryAddDTO.getPostCode());
+    Map<String, Object> deliveryData = new HashMap<>();
+    deliveryData.put("deliveryName", deliveryRedisAddRequestDTO.getDeliveryName());
+    deliveryData.put("userName", deliveryRedisAddRequestDTO.getUserName());
+    deliveryData.put("address", deliveryRedisAddRequestDTO.getAddress());
+    deliveryData.put("phoneNumber", deliveryRedisAddRequestDTO.getPhoneNumber());
+    deliveryData.put("requestDeliveryTime", deliveryRedisAddRequestDTO.getRequestDeliveryTime());
+    deliveryData.put("postCode", deliveryRedisAddRequestDTO.getPostCode());
+    deliveryData.put("isConfirmed", deliveryRedisAddRequestDTO.getIsConfirmed());
 
-      deliveryAddList.add(addDelivery);
-      System.out.println("addDelivery = " + addDelivery);
-    }
+
+    System.out.println("deliveryData = " + deliveryData);
+
+    deliveryAddList.add(deliveryData);
     posData.put("deliveryAddList", deliveryAddList);
+
     System.out.println("deliveryAddList = " + deliveryAddList);
+
     hashOperations.put("CART", compositeId, posData);
   }
 
@@ -72,21 +74,20 @@ public class DeliveryRedisImplRepository implements DeliveryRedisRepository {
 
     List<Object> selectedDeliveryAddress = new ArrayList<>();
 
-    for(DeliveryListRedisSelectDTO deliveryListRedisSelectDTO : deliveryListRedisSelectRequestDTO.getSelectedDeliveryAddress()) {
-      Map<String, Object> selectedAddress = new HashMap<>();
-      selectedAddress.put("deliveryName", deliveryListRedisSelectDTO.getDeliveryName());
-      selectedAddress.put("userName", deliveryListRedisSelectDTO.getUserName());
-      selectedAddress.put("address", deliveryListRedisSelectDTO.getAddress());
-      selectedAddress.put("postCode", deliveryListRedisSelectDTO.getPostCode());
-      selectedAddress.put("isDefault", deliveryListRedisSelectDTO.isDefault());
-      selectedAddress.put("requestDeliveryTime", deliveryListRedisSelectDTO.getRequestDeliveryTime());
-      selectedAddress.put("requestInfo", deliveryListRedisSelectDTO.getRequestInfo());
+    Map<String, Object> selectedAddress = new HashMap<>();
+    selectedAddress.put("deliveryName", deliveryListRedisSelectRequestDTO.getDeliveryName());
+    selectedAddress.put("userName", deliveryListRedisSelectRequestDTO.getUserName());
+    selectedAddress.put("address", deliveryListRedisSelectRequestDTO.getAddress());
+    selectedAddress.put("postCode", deliveryListRedisSelectRequestDTO.getPostCode());
+    selectedAddress.put("isDefault", deliveryListRedisSelectRequestDTO.getIsDefault());
+    selectedAddress.put("requestDeliveryTime", deliveryListRedisSelectRequestDTO.getRequestDeliveryTime());
+    selectedAddress.put("requestInfo", deliveryListRedisSelectRequestDTO.getRequestInfo());
 
-      selectedDeliveryAddress.add(selectedAddress);
-      System.out.println("selectedAddress = " + selectedAddress);
-    }
+    System.out.println("selectedAddress = " + selectedAddress);
 
+    selectedDeliveryAddress.add(selectedAddress);
     posData.put("selectedDeliveryAddress", selectedDeliveryAddress);
+
     System.out.println("selectedDeliveryAddress = " + selectedDeliveryAddress);
     hashOperations.put("CART", compositeId, posData);
   }
@@ -105,14 +106,12 @@ public class DeliveryRedisImplRepository implements DeliveryRedisRepository {
 
     List<Object> giftRecipientInfo = new ArrayList<>();
 
-    for (GiftDTO giftDTO : giftRequestDTO.getGiftRecipientInfo()) {
-      Map<String, Object> recipientInfo = new HashMap<>();
-      recipientInfo.put("receiver", giftDTO.getReceiver());
-      recipientInfo.put("phoneNumber", giftDTO.getPhoneNumber());
-      recipientInfo.put("sender", giftDTO.getSender());
-      giftRecipientInfo.add(recipientInfo);
-      System.out.println("giftRecipientInfo = " + giftRecipientInfo);
-    }
+    Map<String, Object> recipientInfo = new HashMap<>();
+    recipientInfo.put("receiver", giftRequestDTO.getReceiver());
+    recipientInfo.put("phoneNumber", giftRequestDTO.getPhoneNumber());
+    recipientInfo.put("sender", giftRequestDTO.getSender());
+    giftRecipientInfo.add(recipientInfo);
+    System.out.println("giftRecipientInfo = " + giftRecipientInfo);
 
     posData.put("giftRecipientInfo", giftRecipientInfo);
     hashOperations.put("CART", compositeId, posData);
@@ -149,6 +148,60 @@ public class DeliveryRedisImplRepository implements DeliveryRedisRepository {
       }
     }
     return user;
+  }
+
+  @Override
+  public List<Map<String, Object>> findGiftRecipientInfo(String compositeId) {
+    Map<String, List<Object>> posData = (Map<String, List<Object>>) hashOperations.get("CART", compositeId);
+    if (posData != null) {
+      List<Object> giftRecipientList = posData.get("giftRecipientInfo");
+      List<Map<String, Object>> recipientList = new ArrayList<>();
+
+      if (giftRecipientList != null && !giftRecipientList.isEmpty()) {
+        for (Object obj : giftRecipientList) {
+          Map<String, Object> giftRecipient = (Map<String, Object>) obj;
+          recipientList.add(giftRecipient);
+        }
+      }
+      return recipientList;
+    }
+    return null;
+  }
+
+  @Override
+  public List<Map<String, Object>> findAddedDelivery(String compositeId) {
+    Map<String, List<Object>> posData = (Map<String, List<Object>>) hashOperations.get("CART", compositeId);
+    if (posData != null) {
+      List<Object> deliveryAddList = posData.get("deliveryAddList");
+      List<Map<String, Object>> addedDeliveryList = new ArrayList<>();
+
+      if (deliveryAddList != null && !deliveryAddList.isEmpty()) {
+        for (Object obj : deliveryAddList) {
+          Map<String, Object> addedDelivery = (Map<String, Object>) obj;
+          addedDeliveryList.add(addedDelivery);
+        }
+      }
+      return addedDeliveryList;
+    }
+    return null;
+  }
+
+  @Override
+  public List<Map<String, Object>> findSelectedDelivery(String compositeId) {
+    Map<String, List<Object>> posData = (Map<String, List<Object>>) hashOperations.get("CART", compositeId);
+    if (posData != null) {
+      List<Object> selectedDeliveryAddress = posData.get("selectedDeliveryAddress");
+      List<Map<String, Object>> selectedAddress = new ArrayList<>();
+
+      if (selectedDeliveryAddress != null && !selectedDeliveryAddress.isEmpty()) {
+        for (Object obj : selectedDeliveryAddress) {
+          Map<String, Object> deliveryAddress = (Map<String, Object>) obj;
+          selectedAddress.add(deliveryAddress);
+        }
+      }
+      return selectedAddress;
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/com/ssg/webpos/repository/delivery/DeliveryRedisRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/delivery/DeliveryRedisRepository.java
@@ -15,4 +15,7 @@ public interface DeliveryRedisRepository {
   void delete(String id);
   void deleteAll();
   List<String> findByUserId();
+  List<Map<String, Object>> findGiftRecipientInfo(String compositeId);
+  List<Map<String, Object>> findAddedDelivery(String compositeId);
+  List<Map<String, Object>> findSelectedDelivery(String compositeId);
 }

--- a/src/test/java/com/ssg/webpos/service/DeliveryServiceTest.java
+++ b/src/test/java/com/ssg/webpos/service/DeliveryServiceTest.java
@@ -5,7 +5,6 @@ import com.ssg.webpos.domain.enums.DeliveryType;
 import com.ssg.webpos.domain.enums.OrderStatus;
 import com.ssg.webpos.domain.enums.PayMethod;
 import com.ssg.webpos.dto.delivery.DeliveryAddDTO;
-import com.ssg.webpos.dto.delivery.DeliveryRedisAddDTO;
 import com.ssg.webpos.dto.delivery.DeliveryAddressDTO;
 import com.ssg.webpos.repository.UserRepository;
 import com.ssg.webpos.repository.delivery.DeliveryAddressRepository;


### PR DESCRIPTION
- 기존 redis 캐싱 request body 구조를 변경하여 로직 개선(requestDTO에 DTO 타입의 리스트를 사용했는데 'requestDTO' 하나만 사용)
   - API 테스트 시, 리스트 형식으로 FE에서 값을 전달 받는 형식에서 'JSON 객체'로 전달 받는 형식으로 개선
- redis 캐싱된 선물 하기 정보(`sender, receiver, phoneNumber`)를 가져와서(findGiftRecipientInfo) 'delivery 테이블'에 저장하는 메서드(saveGiftInfo)를 GiftController에 구현
- 배송 정보 수집 동의 체크 여부를 확인하기 위해 'Delivery entity'에 '`isConfirmed` 멤버 변수'를 'byte 타입'으로 추가(0: 체크 안함, 1: 체크함)
- redis에 캐싱된 배송 및 선물하기 정보를 가져오기 위해 DeliveryRedisImplRepository에 'findGiftRecipientInfo(선물 받는 사람 캐싱 정보 가져오기)', 'findAddedDelivery(추가된 배송지 캐싱 정보 가져오기)', 'findSelectedDelivery(회원 배송지 목록에서 선택된 배송지 캐싱 정보 가져오기)' 메서드 구현
- DeliveryController에 회원이면 추가한 배송지 정보를 DB에 저장하는 addDeliveryInfo 메서드 구현
   - 캐싱된 `userId`로 해당 user를 찾고 추가된 배송지를 'delivery_list' 테이블에 저장