### PR TITLE
refactor: 주문 취소 로직 개선

### DIFF
--- a/src/main/java/com/ssg/webpos/controller/DeliveryController.java
+++ b/src/main/java/com/ssg/webpos/controller/DeliveryController.java
@@ -2,16 +2,20 @@ package com.ssg.webpos.controller;
 
 import com.ssg.webpos.domain.Delivery;
 import com.ssg.webpos.domain.DeliveryAddress;
+import com.ssg.webpos.domain.Order;
 import com.ssg.webpos.domain.User;
 import com.ssg.webpos.domain.enums.DeliveryStatus;
 import com.ssg.webpos.dto.delivery.DeliveryCheckResponseDTO;
 import com.ssg.webpos.dto.delivery.*;
+import com.ssg.webpos.dto.msg.MessageDTO;
 import com.ssg.webpos.repository.UserRepository;
 import com.ssg.webpos.repository.cart.CartRedisImplRepository;
 import com.ssg.webpos.repository.delivery.DeliveryAddressRepository;
 import com.ssg.webpos.repository.delivery.DeliveryRedisRepository;
 import com.ssg.webpos.repository.delivery.DeliveryRepository;
+import com.ssg.webpos.repository.order.OrderRepository;
 import com.ssg.webpos.service.DeliveryService;
+import com.ssg.webpos.service.SmsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +40,10 @@ public class DeliveryController {
   CartRedisImplRepository cartRedisImplRepository;
   @Autowired
   UserRepository userRepository;
+  @Autowired
+  OrderRepository orderRepository;
+  @Autowired
+  SmsService smsService;
 
   @GetMapping("")
   public ResponseEntity getDeliveryInfo() {
@@ -142,14 +150,17 @@ public class DeliveryController {
 
   // 배송 중
   @GetMapping("/process-delivery/{serialNumber}")
-  public ResponseEntity setStatusProcessDelivery(@PathVariable String serialNumber) {
+  public ResponseEntity setStatusProcessDelivery(@PathVariable String serialNumber, MessageDTO messageDTO) {
     try {
       Delivery findDelivery = deliveryRepository.findBySerialNumber(serialNumber);
+      String phoneNumber = findDelivery.getPhoneNumber();
+      messageDTO.setTo(phoneNumber);
+      Order findOrder = orderRepository.findBySerialNumber(serialNumber);
       System.out.println("findDelivery = " + findDelivery);
       findDelivery.setDeliveryStatus(DeliveryStatus.PROCESS_DELIVERY);
       findDelivery.setStartedDate(LocalDateTime.now());
       deliveryRepository.save(findDelivery);
-
+//      smsService.sendSms()
       return new ResponseEntity(HttpStatus.OK);
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/main/java/com/ssg/webpos/controller/NotificationController.java
+++ b/src/main/java/com/ssg/webpos/controller/NotificationController.java
@@ -1,0 +1,47 @@
+package com.ssg.webpos.controller;
+
+import com.ssg.webpos.domain.BranchAdmin;
+import com.ssg.webpos.dto.notification.NotificationDTO;
+import com.ssg.webpos.repository.BranchAdminRepository;
+import com.ssg.webpos.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/noti")
+public class NotificationController {
+  private final NotificationService notificationService;
+  private final BranchAdminRepository branchAdminRepository;
+  public static Map<Long, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+  @GetMapping(value = "/subscribe/{hqId}", produces = "text/event-stream")
+  public SseEmitter subscribe(@PathVariable Long hqId, @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId, @RequestBody NotificationDTO notificationDTO) {
+    return notificationService.subscribe(hqId, lastEventId, notificationDTO);
+  }
+
+  @PostMapping("/send/{hqId}")
+  public ResponseEntity send(@PathVariable Long hqId, @RequestBody NotificationDTO notificationDTO) {
+    notificationService.send(notificationDTO);
+    return new ResponseEntity(notificationDTO, HttpStatus.OK);
+  }
+
+  @GetMapping("/ui")
+  public String testUi() {
+    return "notificationTest";
+  }
+
+  @GetMapping(value = "/sub/{hq}", produces = "text/event-stream")
+  public SseEmitter connect(@PathVariable Long hq, NotificationDTO notificationDTO) {
+    SseEmitter sseEmitter1 = notificationService.connect(hq);
+    notificationService.sendNoti(hq);
+    return sseEmitter1;
+  }
+}

--- a/src/main/java/com/ssg/webpos/domain/Notification.java
+++ b/src/main/java/com/ssg/webpos/domain/Notification.java
@@ -1,0 +1,44 @@
+package com.ssg.webpos.domain;
+
+import com.ssg.webpos.domain.enums.NotificationType;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class Notification extends BaseTime {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_id")
+  private Long id;
+
+  private String title;
+  private String content;
+  private boolean isRead;
+
+  @Enumerated(EnumType.STRING)
+  private NotificationType notificationType;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "hq_admin_id")
+  private HQAdmin hqAdmin;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "branch_admin_id")
+  private BranchAdmin branchAdmin;
+
+  public Notification(String title, String content, boolean isRead, NotificationType notificationType, HQAdmin hqAdmin, BranchAdmin branchAdmin) {
+    this.title = title;
+    this.content = content;
+    this.isRead = isRead;
+    this.notificationType = notificationType;
+    this.hqAdmin = hqAdmin;
+    this.branchAdmin = branchAdmin;
+  }
+}

--- a/src/main/java/com/ssg/webpos/domain/enums/NotificationType.java
+++ b/src/main/java/com/ssg/webpos/domain/enums/NotificationType.java
@@ -1,0 +1,6 @@
+package com.ssg.webpos.domain.enums;
+
+public enum NotificationType {
+  // 발주 신청
+  ORDER_REQUEST
+}

--- a/src/main/java/com/ssg/webpos/dto/delivery/DeliveryRedisAddRequestDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/delivery/DeliveryRedisAddRequestDTO.java
@@ -17,5 +17,6 @@ public class DeliveryRedisAddRequestDTO {
   private String phoneNumber;
   private String requestDeliveryTime;
   private String postCode;
+  private String requestInfo;
   private byte isConfirmed;
 }

--- a/src/main/java/com/ssg/webpos/dto/notification/NotificationDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/notification/NotificationDTO.java
@@ -1,0 +1,20 @@
+package com.ssg.webpos.dto.notification;
+
+import com.ssg.webpos.domain.HQAdmin;
+import com.ssg.webpos.domain.enums.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationDTO {
+  private HQAdmin hqAdmin;
+  private String title;
+  private String content;
+  private boolean isRead;
+  private NotificationType notificationType;
+}

--- a/src/main/java/com/ssg/webpos/dto/notification/NotificationRequestDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/notification/NotificationRequestDTO.java
@@ -1,0 +1,16 @@
+package com.ssg.webpos.dto.notification;
+
+import com.ssg.webpos.domain.HQAdmin;
+import com.ssg.webpos.domain.enums.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationRequestDTO {
+  private String content;
+  private HQAdmin hqAdmin;
+  private NotificationType notificationType;
+}

--- a/src/main/java/com/ssg/webpos/dto/notification/NotificationResponseDTO.java
+++ b/src/main/java/com/ssg/webpos/dto/notification/NotificationResponseDTO.java
@@ -1,0 +1,26 @@
+package com.ssg.webpos.dto.notification;
+
+import com.ssg.webpos.domain.Notification;
+import com.ssg.webpos.domain.enums.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationResponseDTO {
+  private Long id;
+  private String title;
+  private String content;
+
+  public static NotificationResponseDTO create(Notification notification) {
+    NotificationResponseDTO dto = new NotificationResponseDTO();
+    dto.setId(notification.getId());
+    dto.setTitle(notification.getTitle());
+    dto.setContent(notification.getContent());
+
+    return dto;
+  }
+}

--- a/src/main/java/com/ssg/webpos/repository/delivery/DeliveryRedisImplRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/delivery/DeliveryRedisImplRepository.java
@@ -45,7 +45,7 @@ public class DeliveryRedisImplRepository implements DeliveryRedisRepository {
     deliveryData.put("requestDeliveryTime", deliveryRedisAddRequestDTO.getRequestDeliveryTime());
     deliveryData.put("postCode", deliveryRedisAddRequestDTO.getPostCode());
     deliveryData.put("isConfirmed", deliveryRedisAddRequestDTO.getIsConfirmed());
-
+    deliveryData.put("requestInfo", deliveryRedisAddRequestDTO.getRequestInfo());
 
     System.out.println("deliveryData = " + deliveryData);
 

--- a/src/main/java/com/ssg/webpos/repository/notification/EmitterRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/notification/EmitterRepository.java
@@ -1,0 +1,16 @@
+package com.ssg.webpos.repository.notification;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+  SseEmitter save(String emitterId, SseEmitter sseEmitter);
+  void saveEventCache(String emitterId, Object event);
+  // 해당 hqAdmin과 관련된 모든 emitter를 찾음
+  Map<String, SseEmitter> findAllEmitterStartWithByHqId(String hqId);
+  // 해당 hqAdmin과 관련된 모든 event를 찾음
+  Map<String, Object> findAllEventCacheStartWithByHqId(String hqId);
+
+  void deleteById(String emitterId);
+}

--- a/src/main/java/com/ssg/webpos/repository/notification/EmitterRepository1.java
+++ b/src/main/java/com/ssg/webpos/repository/notification/EmitterRepository1.java
@@ -1,0 +1,35 @@
+package com.ssg.webpos.repository.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+public class EmitterRepository1 {
+  private Map<String, SseEmitter> emitterMap = new HashMap<>();
+
+  public SseEmitter save(Long hqId, SseEmitter sseEmitter) {
+    emitterMap.put(getKey(hqId), sseEmitter);
+    log.info("Saved SseEmitter for {}", hqId);
+    return sseEmitter;
+  }
+
+  public Optional<SseEmitter> get(Long hqId) {
+    log.info("Got SseEmitter for {}", hqId);
+    return Optional.ofNullable(emitterMap.get(getKey(hqId)));
+  }
+
+  public void delete(Long hqId) {
+    emitterMap.remove(getKey(hqId));
+    log.info("Deleted SseEmitter for {}", hqId);
+  }
+
+  private String getKey(Long hqId) {
+    return "Emitter:UID: " + hqId;
+  }
+}

--- a/src/main/java/com/ssg/webpos/repository/notification/EmitterRepositoryImpl.java
+++ b/src/main/java/com/ssg/webpos/repository/notification/EmitterRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.ssg.webpos.repository.notification;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+  // 동시성을 고려하여 ConcurrentHashmap 사용
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+  private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+  @Override
+  public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+    emitters.put(emitterId, sseEmitter);
+    return sseEmitter;
+  }
+
+  @Override
+  public void saveEventCache(String eventCacheId, Object event) {
+    eventCache.put(eventCacheId, event);
+  }
+
+  @Override
+  public Map<String, SseEmitter> findAllEmitterStartWithByHqId(String hqId) {
+    return emitters.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(hqId))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, Object> findAllEventCacheStartWithByHqId(String hqId) {
+    return eventCache.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(hqId))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public void deleteById(String id) {
+    emitters.remove(id);
+  }
+}

--- a/src/main/java/com/ssg/webpos/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/ssg/webpos/repository/notification/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.ssg.webpos.repository.notification;
+
+import com.ssg.webpos.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/ssg/webpos/service/CartService.java
+++ b/src/main/java/com/ssg/webpos/service/CartService.java
@@ -6,10 +6,7 @@ import com.ssg.webpos.domain.enums.OrderStatus;
 import com.ssg.webpos.domain.enums.PayMethod;
 import com.ssg.webpos.dto.cartDto.CartAddDTO;
 import com.ssg.webpos.dto.OrderDTO;
-import com.ssg.webpos.repository.CouponRepository;
-import com.ssg.webpos.repository.PointSaveHistoryRepository;
-import com.ssg.webpos.repository.PointUseHistoryRepository;
-import com.ssg.webpos.repository.UserRepository;
+import com.ssg.webpos.repository.*;
 import com.ssg.webpos.repository.cart.CartRepository;
 import com.ssg.webpos.repository.order.OrderRepository;
 import com.ssg.webpos.repository.pos.PosRepository;
@@ -32,6 +29,7 @@ public class CartService {
   private final PointUseHistoryRepository pointUseHistoryRepository;
   private final PointSaveHistoryRepository pointSaveHistoryRepository;
   private final CouponRepository couponRepository;
+  private final PointRepository pointRepository;
 
   // 장바구니 상품 개별 삭제
   @Transactional
@@ -119,10 +117,14 @@ public class CartService {
     Order order = orderRepository.findById(orderId).orElseThrow(
         () -> new RuntimeException("주문 내역을 찾을 수 없습니다."));
     order.setOrderStatus(OrderStatus.CANCEL);
+    orderRepository.save(order);
+
     User findUser = userRepository.findById(userId).get();
+    Long pointId = findUser.getPoint().getId();
+    Point findPoint = pointRepository.findById(pointId).get();
 
     // 사용한 포인트 반환
-    int currentPoint = findUser.getPoint().getPointAmount();
+    int currentPoint = findPoint.getPointAmount();
     System.out.println("currentPoint = " + currentPoint);
 
     PointUseHistory findUsePoint = pointUseHistoryRepository.findByOrderId(orderId).orElseThrow(
@@ -133,8 +135,7 @@ public class CartService {
     currentPoint += usePointAmount;
     System.out.println("currentPoint = " + currentPoint);
 
-//    findUser.setPoint();
-    userRepository.save(findUser);
+    //pointRepository.save(findPoint);
     findUsePoint.setPointStatus((byte) 1);
     pointUseHistoryRepository.save(findUsePoint);
 
@@ -150,8 +151,8 @@ public class CartService {
     currentPoint -= savePointAmount;
     System.out.println("currentPoint = " + currentPoint);
 
-//    findUser.setPoint(currentPoint);
-    userRepository.save(findUser);
+    findPoint.setPointAmount(currentPoint);
+    pointRepository.save(findPoint);
     findSavePoint.setPointStatus((byte) 1);
     pointSaveHistoryRepository.save(findSavePoint);
 

--- a/src/main/java/com/ssg/webpos/service/NotificationService.java
+++ b/src/main/java/com/ssg/webpos/service/NotificationService.java
@@ -1,0 +1,143 @@
+package com.ssg.webpos.service;
+
+import com.ssg.webpos.controller.NotificationController;
+import com.ssg.webpos.domain.Notification;
+import com.ssg.webpos.domain.enums.NotificationType;
+import com.ssg.webpos.dto.notification.NotificationDTO;
+import com.ssg.webpos.dto.notification.NotificationResponseDTO;
+import com.ssg.webpos.repository.notification.EmitterRepository;
+import com.ssg.webpos.repository.notification.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+  private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+  private final EmitterRepository emitterRepository;
+  private final NotificationRepository notificationRepository;
+
+  // Last-Event-ID 헤더는 클라이언트가 마지막으로 수신한 데이터 id 값
+  @Transactional
+  public SseEmitter subscribe(Long hqId, String lastEventId, NotificationDTO notificationDTO) {
+    String emitterId = makeTimeIncludeId(hqId);
+    // 클라이언트의 sse 연결 요청에 응답하기 위해서 SseEmitter 객체를 만들어 반환
+    // SseEmitter 객체를 만들 때 유효시간을 주어, 주는 시간만큼 sse 연결이 유지되고 시간이 지나면 자동으로 클라이언트에서 재연결 요청을 보냄
+    SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+    // SseEmitter의 시간 초과 및 네트워크 오류를 포함한 모든 이유로 비동기 요청이 정상 동작할 수 없다면 저장해둔 SseEmitter를 삭제
+    emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+    emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+    // 503 에러를 방지하기 위한 더미 이벤트 전송
+    String eventId = makeTimeIncludeId(hqId);
+//    sendNotification(emitter, eventId, emitterId, "EventStream Created. [hqId=" + hqId + "]");
+    sendNotification(emitter, eventId, emitterId, notificationDTO);
+    // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실 예방
+    if (hasLostData(lastEventId)) {
+      sendLostData(lastEventId, hqId, emitterId, emitter);
+    }
+//    emitter.complete();
+    return emitter;
+  }
+
+  private String makeTimeIncludeId(Long hqId) {
+    // 유실된 데이터 전송을 위함(id 값 그대로 사용하면 어떤 데이터까지 제대로 전송되었는지 알 수 없음)
+    // 데이터가 유실된 시점을 파악하여 저장된 key 값 비교를 통해 유실된 데이터만 재전송
+    return hqId + "_" + System.currentTimeMillis();
+  }
+
+  public void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+    try {
+      emitter.send(SseEmitter.event()
+          .id(eventId)
+          .data(data));
+    } catch (IOException exception) {
+      emitterRepository.deleteById(emitterId);
+    }
+  }
+
+  // lastEventId가 존재한다는 것은 받지 못한 데이터가 있다는 것
+  private boolean hasLostData(String lastEventId) {
+    return !lastEventId.isEmpty();
+  }
+
+  // 받지 못한 데이터가 있다면 lastEventId를 기준으로 그 뒤의 데이터를 추출해 알림을 보내줌
+  private void sendLostData(String lastEventId, Long hqId, String emitterId, SseEmitter emitter) {
+    Map<String, SseEmitter> eventCaches = emitterRepository.findAllEmitterStartWithByHqId(String.valueOf(hqId));
+    System.out.println("eventCaches = " + eventCaches);
+    eventCaches.entrySet().stream()
+        .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+        .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+  }
+
+  @Transactional
+  public void send(NotificationDTO notificationDTO) {
+    Notification notification = notificationRepository.save(createNotification(notificationDTO));
+    System.out.println("notification = " + notification);
+
+    String hqId = String.valueOf(notification.getId());
+    String eventId = notificationDTO.getHqAdmin() + "_" + System.currentTimeMillis();
+    Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByHqId(hqId);
+    System.out.println("emitters = " + emitters);
+
+    emitters.forEach((key, emitter) -> {
+      emitterRepository.saveEventCache(key, notification);
+      sendNotification(emitter, eventId, key, NotificationResponseDTO.create(notification));
+    });
+  }
+
+  private Notification createNotification(NotificationDTO notificationDTO) {
+    return Notification.builder()
+        .hqAdmin(notificationDTO.getHqAdmin())
+        .title(notificationDTO.getTitle())
+        .content(notificationDTO.getContent())
+        .isRead(notificationDTO.isRead())
+        .notificationType(notificationDTO.getNotificationType())
+        .build();
+  }
+
+  public SseEmitter connect(Long hqId) {
+    SseEmitter sseEmitter = new SseEmitter(Long.MAX_VALUE);
+    try {
+      sseEmitter.send(SseEmitter.event().name("connect").data("hqId=[" + hqId + "]"));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    NotificationController.sseEmitters.put(hqId, sseEmitter);
+    sseEmitter.onCompletion(() -> NotificationController.sseEmitters.remove(hqId));
+    sseEmitter.onTimeout(() -> NotificationController.sseEmitters.remove(hqId));
+    sseEmitter.onError((e) -> NotificationController.sseEmitters.remove(hqId));
+
+    return sseEmitter;
+  }
+
+  @Transactional
+  public void sendNoti(Long hqId) {
+    NotificationDTO notificationDTO = NotificationDTO.builder()
+        .notificationType(NotificationType.ORDER_REQUEST)
+        .content("branch에서 발주 신청이 되었습니다.")
+        .build();
+    if(notificationDTO.getNotificationType().equals(NotificationType.ORDER_REQUEST)) {
+      notificationDTO.setTitle("[발주 신청 알림]");
+    }
+    Notification notification = createNotification(notificationDTO);
+    System.out.println("notification = " + notification);
+    SseEmitter sseEmitter = NotificationController.sseEmitters.get(hqId);
+    String notiMsg = notification.getTitle()
+        + notification.getContent();
+    try {
+      sseEmitter.send(SseEmitter.event().name("notification").data(notiMsg));
+//      sseEmitter.complete();
+    } catch (Exception e) {
+      NotificationController.sseEmitters.remove(hqId);
+    }
+  }
+}

--- a/src/main/java/com/ssg/webpos/service/NotificationService1.java
+++ b/src/main/java/com/ssg/webpos/service/NotificationService1.java
@@ -1,0 +1,57 @@
+package com.ssg.webpos.service;
+
+import com.ssg.webpos.repository.notification.EmitterRepository1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService1 {
+  private final static Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 1시간
+  private final static String NOTIFICATION_NAME = "notify";
+  private final EmitterRepository1 emitterRepository;
+
+  public SseEmitter connectNotification(Long hqId) {
+    // 새로운 SseEmitter를 만듦
+    SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+    // hqId로 SseEmitter를 저장
+    emitterRepository.save(hqId, sseEmitter);
+    // 세션이 종료될 경우 저장한 SseEmitter를 삭제
+    sseEmitter.onCompletion(() -> emitterRepository.delete(hqId));
+    sseEmitter.onTimeout(() -> emitterRepository.delete(hqId));
+
+    // 503 Service Unavailable 오류가 발생하지 않도록 첫 데이터를 보냄
+    try {
+      sseEmitter.send(SseEmitter.event()
+          .id("")
+          .name(NOTIFICATION_NAME)
+          .data("Connection completed"));
+      System.out.println("send complete");
+    } catch (IOException exception) {
+      throw new RuntimeException("연결 오류!");
+    }
+    return sseEmitter;
+  }
+
+  public void send(Long hqId, Long notificationId) {
+    // hqId로 SseEmitter를 찾아 이벤트 발생 시킴
+    emitterRepository.get(hqId).ifPresentOrElse(sseEmitter -> {
+      try {
+        sseEmitter.send(SseEmitter.event()
+            .id(notificationId.toString())
+            .name(NOTIFICATION_NAME)
+            .data("New notification"));
+        System.out.println("new notification");
+      } catch (IOException exception) {
+        // IOException이 발생하면 저장된 SseEmitter를 삭제하고 예외 발생시킴
+        emitterRepository.delete(hqId);
+        throw new RuntimeException("연결 오류!");
+      }
+    }, () -> log.info("No emitter found"));
+  }
+}

--- a/src/main/java/com/ssg/webpos/service/SmsService.java
+++ b/src/main/java/com/ssg/webpos/service/SmsService.java
@@ -108,13 +108,20 @@ public class SmsService {
   // sms 보낼 내용 작성
   public String makeSmsContent(Delivery savedDelivery, Order savedOrder, String giftUrl) {
     GiftSmsDTO smsInfo = getInfoToUseInGiftSms(savedDelivery, savedOrder);
+
+    String giftProductName = smsInfo.getGiftProductName();
+    if(giftProductName.length() > 10) {
+      giftProductName = giftProductName.substring(0, 10) + "...";
+    }
+
     String content1 = "[선물이 도착했어요!]\n"
         + smsInfo.getSender() + "님이 " + smsInfo.getReceiver() + "님에게 선물을 보냈습니다.\n"
         + "아래 링크를 통해 선물을 확인하시고 배송지를 입력해주세요.\n\n"
-        + "▶ 상품명: " + smsInfo.getGiftProductName() + "\n"
+        + "▶ 상품명: " + giftProductName + "\n"
         + "▶ 선물 보러 가기: " + giftUrl + "\n"
         + "▶ 배송지 입력 기한: " + smsInfo.getEntryDeadline() + " 까지\n\n"
         + "* 기한 내에 배송지 미입력 시, 주문이 자동 취소됩니다.";
+    System.out.println("content1 = " + content1);
     String content = smsInfo.getSender() + ", " + smsInfo.getReceiver() + "\n"
         + smsInfo.getGiftProductName() + "\n"
         + giftUrl + "\n"
@@ -134,6 +141,7 @@ public class SmsService {
 
     String content = makeSmsContent(savedDelivery, savedOrder, messageDTO.getGiftUrl());
     messageDTO.setContent(content);
+    messageDTO.setTo(savedDelivery.getPhoneNumber());
 
     List<MessageDTO> messages = new ArrayList<>();
     messages.add(messageDTO);

--- a/src/main/resources/templates/notificationTest.html
+++ b/src/main/resources/templates/notificationTest.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SSE 알림 테스트</title>
+</head>
+<body>
+<h1>SSE 알림 테스트</h1>
+
+<script>
+    const eventSource = new EventSource('/api/v1/noti/send/1'); // hqId를 1로 설정하거나 적절한 hqId를 사용합니다.
+
+    eventSource.addEventListener('notification', function(event) {
+        const notificationData = event.data;
+        console.log(event.data)
+        console.log('받은 알림:', notificationData);
+        alert('새로운 알림이 도착했습니다: ' + notificationData);
+    });
+</script>
+</body>
+</html>

--- a/src/test/java/com/ssg/webpos/WebposApplicationTests.java
+++ b/src/test/java/com/ssg/webpos/WebposApplicationTests.java
@@ -22,7 +22,7 @@ class WebposApplicationTests {
 				.branchName("센텀점")
 				.address("부산 해운대")
 				.name("신세계 백화점")
-				.postCode("1234") // java: incompatible types: int cannot be converted to java.lang.String 에러로 수정했습니다.
+				.postCode("12345")
 				.build();
 		storeRepository.save(newStore);
 	}

--- a/src/test/java/com/ssg/webpos/repository/DeliveryRedisRepositoryTest.java
+++ b/src/test/java/com/ssg/webpos/repository/DeliveryRedisRepositoryTest.java
@@ -48,6 +48,7 @@ public class DeliveryRedisRepositoryTest {
         .requestDeliveryTime("14:00~16:00")
         .postCode("48060")
         .isConfirmed((byte) 1)
+        .requestInfo("부재 시, 경비실에 맡겨주세요.")
         .build();
     deliveryAddList.add(deliveryRedisAddRequestDTO);
     System.out.println("deliveryAddDTO = " + deliveryRedisAddRequestDTO);
@@ -141,6 +142,7 @@ public class DeliveryRedisRepositoryTest {
         .address("부산광역시 남구")
         .requestDeliveryTime("12:00~15:00")
         .postCode("052508")
+        .requestInfo("부재 시, 경비실에 맡겨주세요.")
         .build();
     deliveryRedisImplRepository.saveDelivery(deliveryRedisAddRequestDTO);
 

--- a/src/test/java/com/ssg/webpos/repository/EmitterRepositoryImplTest.java
+++ b/src/test/java/com/ssg/webpos/repository/EmitterRepositoryImplTest.java
@@ -1,0 +1,76 @@
+package com.ssg.webpos.repository;
+
+import com.ssg.webpos.domain.HQAdmin;
+import com.ssg.webpos.domain.Notification;
+import com.ssg.webpos.domain.enums.NotificationType;
+import com.ssg.webpos.repository.notification.EmitterRepository;
+import com.ssg.webpos.repository.notification.EmitterRepositoryImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import javax.transaction.Transactional;
+import java.util.Map;
+
+@SpringBootTest
+@Transactional
+public class EmitterRepositoryImplTest {
+  @Autowired
+  private HQAdminRepository hqAdminRepository;
+  private EmitterRepository emitterRepository = new EmitterRepositoryImpl();
+  private Long DEFAULT_TIMEOUT = 60L * 1000L * 60L;
+
+  @Test
+  @DisplayName("새로운 Emitter 추가")
+  public void save() {
+    // given
+    Long hqId = 1L;
+    String emitterId = hqId + "_" + System.currentTimeMillis();
+    System.out.println("emitterId = " + emitterId);
+    SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+    Assertions.assertDoesNotThrow(() -> emitterRepository.save(emitterId, sseEmitter));
+  }
+
+  @Test
+  @DisplayName("수신한 이벤트를 캐시에 저장")
+  public void saveEventCache() {
+    Long hqId = 1L;
+    String eventCacheId = hqId + "_" + System.currentTimeMillis();
+    HQAdmin hqAdmin = hqAdminRepository.findById(hqId).get();
+
+    Notification notification = Notification.builder()
+        .title("발주 신청")
+        .hqAdmin(hqAdmin)
+        .content("테스트입니다.")
+        .isRead(false)
+        .notificationType(NotificationType.ORDER_REQUEST)
+        .build();
+    System.out.println("notification = " + notification);
+    Assertions.assertDoesNotThrow(() -> emitterRepository.saveEventCache(eventCacheId, notification));
+  }
+
+  @Test
+  @DisplayName("어떤 회원이 접속한 모든 Emitter를 찾는다")
+  public void findAllEmitterStartWithByHqId() throws InterruptedException {
+    Long hqId = 1L;
+    String emitterId1 = hqId + "_" + System.currentTimeMillis();
+    emitterRepository.save(emitterId1, new SseEmitter(DEFAULT_TIMEOUT));
+
+    Thread.sleep(100);
+    String emitterId2 = hqId + "_" + System.currentTimeMillis();
+    emitterRepository.save(emitterId2, new SseEmitter(DEFAULT_TIMEOUT));
+
+    Thread.sleep(100);
+    String emitterId3 = hqId + "_" + System.currentTimeMillis();
+    emitterRepository.save(emitterId3, new SseEmitter(DEFAULT_TIMEOUT));
+
+    Map<String, SseEmitter> ActualResult = emitterRepository.findAllEmitterStartWithByHqId(String.valueOf(hqId));
+    System.out.println("ActualResult = " + ActualResult);
+
+    Assertions.assertEquals(3, ActualResult.size());
+  }
+}

--- a/src/test/java/com/ssg/webpos/service/NotificationServiceTest.java
+++ b/src/test/java/com/ssg/webpos/service/NotificationServiceTest.java
@@ -1,0 +1,62 @@
+package com.ssg.webpos.service;
+
+import com.ssg.webpos.domain.HQAdmin;
+import com.ssg.webpos.domain.Store;
+import com.ssg.webpos.domain.enums.NotificationType;
+import com.ssg.webpos.domain.enums.RoleHQadmin;
+import com.ssg.webpos.dto.notification.NotificationDTO;
+import com.ssg.webpos.repository.store.StoreRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import javax.transaction.Transactional;
+
+@SpringBootTest
+@Transactional
+class NotificationServiceTest {
+	@Autowired
+	NotificationService notificationService;
+
+	@Test
+	@DisplayName("알림 구독 테스트")
+	void subscribe() {
+		HQAdmin hqAdmin = new HQAdmin();
+		hqAdmin.setAdminNumber("12345");
+		hqAdmin.setName("관리자A");
+		hqAdmin.setPassword("1234");
+		hqAdmin.setRole(RoleHQadmin.ROLE_HQ);
+
+		String lastEventId = "";
+
+//		Assertions.assertDoesNotThrow(() -> notificationService.subscribe(hqAdmin.getId(), lastEventId));
+	}
+
+	@Test
+	@DisplayName("알림 메시지 전송")
+	public void send() {
+		HQAdmin hqAdmin = new HQAdmin();
+		hqAdmin.setAdminNumber("22222");
+		hqAdmin.setName("관리자B");
+		hqAdmin.setPassword("1234");
+		hqAdmin.setRole(RoleHQadmin.ROLE_HQ);
+
+		String lastEventId = "";
+//		notificationService.subscribe(hqAdmin.getId(), lastEventId);
+		NotificationDTO notificationDTO = NotificationDTO.builder()
+				.hqAdmin(hqAdmin)
+				.title("발주 신청 안내")
+				.content("발주 신청이 완료되었습니다.")
+				.isRead(false)
+				.notificationType(NotificationType.ORDER_REQUEST)
+				.build();
+		System.out.println("notificationDTO = " + notificationDTO);
+		Assertions.assertDoesNotThrow(() -> notificationService.send(notificationDTO));
+
+	}
+}

--- a/src/test/java/com/ssg/webpos/service/SmsServiceTest.java
+++ b/src/test/java/com/ssg/webpos/service/SmsServiceTest.java
@@ -30,23 +30,25 @@ class SmsServiceTest {
   @Test
   @DisplayName("문자 메시지 전송 테스트")
   void sendSmsTest() throws UnsupportedEncodingException, URISyntaxException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
-    Long deliveryId = 17L;
-    Long orderId = 171L;
+    Long deliveryId = 62L;
+    Long orderId = 10L;
     Delivery findDelivery = deliveryRepository.findById(deliveryId).get();
+    System.out.println("findDelivery = " + findDelivery);
     Order findOrder = orderRepository.findById(orderId).get();
+    System.out.println("findOrder = " + findOrder);
     String giftUrl = "http://localhost:3000/entry-address";
 
     MessageDTO msgDTO = new MessageDTO();
-    msgDTO.setTo("01012345678");
+//    msgDTO.setTo("01012345678");
     msgDTO.setGiftUrl(giftUrl);
-//    smsService.sendSms(msgDTO,findDelivery, findOrder);
+    smsService.sendSms(msgDTO,findDelivery, findOrder);
   }
 
   @Test
   @DisplayName("문자 메시지 내용 테스트")
   void smsContentTest() {
-    Long deliveryId = 17L;
-    Long orderId = 171L;
+    Long deliveryId = 62L;
+    Long orderId = 10L;
     Delivery findDelivery = deliveryRepository.findById(deliveryId).get();
     Order findOrder = orderRepository.findById(orderId).get();
     String giftUrl = "http://localhost:3000/entry-address";


### PR DESCRIPTION
- Point 엔티티 생성으로 CartService 클래스에서 `주문 취소 메서드(cancelOrder)` 로직 개선
   - 기존에 user 테이블에서 point를 찾아서 포인트 사용/적립 취소 기능을 구현했는데, point 테이블에서 해당 유저의 포인트 사용/적립을 취소시키는 로직으로 변경